### PR TITLE
Improve overall performance for sqlite

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "sqlite",
  "tauri",
  "tauri-build",
+ "thiserror",
 ]
 
 [[package]]
@@ -2861,18 +2862,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ tauri = { version = "1", features = ["shell-open"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlite = "0.36.0"
+thiserror = "1.0.61"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -1,24 +1,79 @@
 /* Connect to SQLite database */
 
-use sqlite;
+use sqlite::{Connection, Error};
+use thiserror::Error;
+
+/* Error handling */
+enum DBErrors {
+    #[error("Failed to connect to the database")]
+    ConnectionError(#[from] Error),
+    #[error("Failed to execute query")]
+    QueryError(#[from] Error),
+}
 
 /*
 *** Connect to the database ***
-* TODO: the database if not exists it creates one, put a default directory
-        for the installation (if not it will create the database in the current directory)
-* This function returns a connection to the database
+* Return: Connection or Error
 */
-pub fn connect() -> sqlite::Connection {
-    let conn = sqlite::open("ss.db").unwrap();
-    create_table(&conn);
-    conn
+pub fn connect() -> Result<Connection, DBErrors> {
+    let conn = sqlite::open("ss.db")?;
+    create_table(&conn)?;
+    Ok(conn)
 }
 
-// Create table if not exists
-fn create_table(conn: &sqlite::Connection) {
+// Create tables
+// It checks if the table exists, if not, it creates it
+fn create_table(conn: &Connection) -> Result<(), DBErrors> {
+    if !table_exists(conn, "users")? {
+        users_table(conn)?;
+    }
+
+    if !table_exists(conn, "classrooms")? {
+        classrooms_table(conn)?;
+    }
+
+    if !table_exists(conn, "groups")? {
+        groups_table(conn)?;
+    }
+
+    if !table_exists(conn, "subjects")? {
+        subjects_table(conn)?;
+    }
+
+    if !table_exists(conn, "teachers")? {
+        teachers_table(conn)?;
+    }
+}
+
+/*
+*** Check if table exists ***
+* Why?
+- Minimal Query Overhead: The table_exists function runs a simple query against
+    the sqlite_master table, which is a lightweight operation.
+- Avoid unnecessary table creation: If the table already exists, we can avoid
+    executing the CREATE TABLE statement, which can be a costly operation.
+
+* Return: bool or Error if cannot execute the query
+*/
+fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, DBErrors> {
+    let mut result = false;
+    let mut statement = conn.prepare(&format!(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='{}'",
+        table_name
+    ))?;
+
+    /* Here we iterate over the rows of the result if any it means the table exists */
+    while let sqlite::State::Row = statement.next()? {
+        result = true;
+    }
+
+    Ok(result)
+}
+
+fn users_table(conn: &Connection) -> Result<(), DBErrors> {
     conn.execute(
         "
-        CREATE TABLE IF NOT EXISTS users (
+        CREATE TABLE users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             email TEXT NOT NULL,
             name TEXT NOT NULL,
@@ -26,12 +81,15 @@ fn create_table(conn: &sqlite::Connection) {
             password TEXT NOT NULL
         )
         ",
-    )
-    .unwrap();
+    )?;
 
+    Ok(())
+}
+
+fn classrooms_table(conn: &Connection) -> Result<(), DBErrors> {
     conn.execute(
         "
-        CREATE TABLE IF NOT EXISTS classrooms (
+        CREATE TABLE classrooms (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             number INTEGER NOT NULL,
             building TEXT NOT NULL,
@@ -39,11 +97,15 @@ fn create_table(conn: &sqlite::Connection) {
             capacity INTEGER NOT NULL,
         )
         ",
-    ).unwrap();
+    )?;
 
+    Ok(())
+}
+
+fn groups_table(conn: &Connection) -> Result<(), DBErrors> {
     conn.execute(
         "
-        CREATE TABLE IF NOT EXISTS groups (
+        CREATE TABLE groups (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             grade INTEGER NOT NULL,
             group TEXT NOT NULL,
@@ -52,11 +114,15 @@ fn create_table(conn: &sqlite::Connection) {
             students_quantity INTEGER NOT NULL,
         )
         ",
-    ).unwrap();
-            
+    )?;
+
+    Ok(())
+}
+
+fn subjects_table(conn: &Connection) -> Result<(), DBErrors> {
     conn.execute(
         "
-        CREATE TABLE IF NOT EXISTS subjects (
+        CREATE TABLE subjects (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
             abbreviation TEXT NOT NULL,
@@ -65,8 +131,12 @@ fn create_table(conn: &sqlite::Connection) {
             teacher_id INTEGER NOT NULL,
         )
         ",
-    ).unwrap();
+    )?;
 
+    Ok(())
+}
+
+fn teachers_table(conn: &Connection) -> Result<(), DBErrors> {
     conn.execute(
         "
         CREATE TABLE IF NOT EXISTS teachers (
@@ -77,22 +147,9 @@ fn create_table(conn: &sqlite::Connection) {
             email TEXT NOT NULL,
             commissioned_hours INTEGER NOT NULL,
             active_hours INTEGER NOT NULL,
-            general_stars INTEGER NOT NULL,
+            general_stars INTEGER NOT NULL
         )
         ",
-    ).unwrap();
-
-    conn.execute(
-        "
-        CREATE TABLE IF NOT EXISTS schedules (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            subject_id INTEGER NOT NULL,
-            group_id INTEGER NOT NULL,
-            classroom_id INTEGER NOT NULL,
-            day TEXT NOT NULL,
-            start_time TEXT NOT NULL,
-            end_time TEXT NOT NULL,
-        )
-        ",
-    ).unwrap();
+    )?;
+    Ok(())
 }

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -1,47 +1,38 @@
 /* Connect to SQLite database */
 
 use sqlite::{Connection, Error};
-use thiserror::Error;
-
-/* Error handling */
-enum DBErrors {
-    #[error("Failed to connect to the database")]
-    ConnectionError(#[from] Error),
-    #[error("Failed to execute query")]
-    QueryError(#[from] Error),
-}
 
 /*
 *** Connect to the database ***
 * Return: Connection or Error
 */
-pub fn connect() -> Result<Connection, DBErrors> {
-    let conn = sqlite::open("ss.db")?;
-    create_table(&conn)?;
-    Ok(conn)
+pub fn connect() -> Connection {
+    let conn = sqlite::open("ss.db");
+    create_table(&conn.as_ref().unwrap());
+    conn.unwrap()
 }
 
 // Create tables
 // It checks if the table exists, if not, it creates it
-fn create_table(conn: &Connection) -> Result<(), DBErrors> {
-    if !table_exists(conn, "users")? {
-        users_table(conn)?;
+fn create_table(conn: &Connection) {
+    if !table_exists(&conn, "users").unwrap() {
+        users_table(&conn);
     }
 
-    if !table_exists(conn, "classrooms")? {
-        classrooms_table(conn)?;
+    if !table_exists(&conn, "classrooms").unwrap() {
+        classrooms_table(&conn);
     }
 
-    if !table_exists(conn, "groups")? {
-        groups_table(conn)?;
+    if !table_exists(&conn, "groups").unwrap() {
+        groups_table(&conn);
     }
 
-    if !table_exists(conn, "subjects")? {
-        subjects_table(conn)?;
+    if !table_exists(&conn, "subjects").unwrap() {
+        subjects_table(&conn);
     }
 
-    if !table_exists(conn, "teachers")? {
-        teachers_table(conn)?;
+    if !table_exists(&conn, "teachers").unwrap() {
+        teachers_table(&conn);
     }
 }
 
@@ -55,7 +46,7 @@ fn create_table(conn: &Connection) -> Result<(), DBErrors> {
 
 * Return: bool or Error if cannot execute the query
 */
-fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, DBErrors> {
+fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, Error> {
     let mut result = false;
     let mut statement = conn.prepare(&format!(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='{}'",
@@ -70,7 +61,7 @@ fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, DBErrors> {
     Ok(result)
 }
 
-fn users_table(conn: &Connection) -> Result<(), DBErrors> {
+fn users_table(conn: &Connection) {
     conn.execute(
         "
         CREATE TABLE users (
@@ -81,12 +72,10 @@ fn users_table(conn: &Connection) -> Result<(), DBErrors> {
             password TEXT NOT NULL
         )
         ",
-    )?;
-
-    Ok(())
+    ).unwrap();
 }
 
-fn classrooms_table(conn: &Connection) -> Result<(), DBErrors> {
+fn classrooms_table(conn: &Connection) {
     conn.execute(
         "
         CREATE TABLE classrooms (
@@ -97,12 +86,10 @@ fn classrooms_table(conn: &Connection) -> Result<(), DBErrors> {
             capacity INTEGER NOT NULL,
         )
         ",
-    )?;
-
-    Ok(())
+    ).unwrap();
 }
 
-fn groups_table(conn: &Connection) -> Result<(), DBErrors> {
+fn groups_table(conn: &Connection) {
     conn.execute(
         "
         CREATE TABLE groups (
@@ -114,12 +101,10 @@ fn groups_table(conn: &Connection) -> Result<(), DBErrors> {
             students_quantity INTEGER NOT NULL,
         )
         ",
-    )?;
-
-    Ok(())
+    ).unwrap();
 }
 
-fn subjects_table(conn: &Connection) -> Result<(), DBErrors> {
+fn subjects_table(conn: &Connection) {
     conn.execute(
         "
         CREATE TABLE subjects (
@@ -131,12 +116,10 @@ fn subjects_table(conn: &Connection) -> Result<(), DBErrors> {
             teacher_id INTEGER NOT NULL,
         )
         ",
-    )?;
-
-    Ok(())
+    ).unwrap();
 }
 
-fn teachers_table(conn: &Connection) -> Result<(), DBErrors> {
+fn teachers_table(conn: &Connection) {
     conn.execute(
         "
         CREATE TABLE IF NOT EXISTS teachers (
@@ -150,6 +133,5 @@ fn teachers_table(conn: &Connection) -> Result<(), DBErrors> {
             general_stars INTEGER NOT NULL
         )
         ",
-    )?;
-    Ok(())
+    ).unwrap();
 }


### PR DESCRIPTION
I added i way that doesn't execute query CREATE TABLE because it could affect performance.

# Reasons
- Minimal Query Overhead: The table_exists function runs a simple query against the sqlite_master table, which is a lightweight operation.

- Avoiding Unnecessary Execution: The CREATE TABLE IF NOT EXISTS statement, while optimized, still involves parsing and some level of execution planning by SQLite.

### Pros: Explicit checks, avoids unnecessary parsing and execution planning.
### Cons: Slight overhead of additional query per table.

# TODOS
Still the code isn't perfect, we need to implement a way to handle possible errors from database and avoid app to crash.